### PR TITLE
Switch PostgreSQL driver to postgres.js

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1,28 +1,24 @@
-const { Pool } = require('pg');
+const postgres = require('postgres');
 
-let pool;
+const sql = postgres({
+  max: 10,
+});
 
 (async () => {
   try {
-    pool = new Pool();
     // check for existence of tables
-    const queryText = 'SELECT $1::regclass';
     await Promise.all(
       ['questions', 'answers', 'answers_photos'].map(
-        async (table) => await pool.query(queryText, [table])
+        async (table) => await sql`SELECT ${table}::regclass`
       )
     );
     console.log('Connected to database!');
   } catch (error) {
     console.log('Unable to connect to database');
     console.log(error);
-    await pool.end();
   }
 })();
 
 module.exports = {
-  query: async (text, params) => await pool.query(text, params),
-  end: async () => {
-    pool.end();
-  },
+  sql,
 };

--- a/db/index.js
+++ b/db/index.js
@@ -19,6 +19,4 @@ const sql = postgres({
   }
 })();
 
-module.exports = {
-  sql,
-};
+module.exports = sql;

--- a/db/index.js
+++ b/db/index.js
@@ -9,7 +9,7 @@ const sql = postgres({
     // check for existence of tables
     await Promise.all(
       ['questions', 'answers', 'answers_photos'].map(
-        async (table) => await sql`SELECT ${table}::regclass`
+        async (table) => sql`SELECT ${table}::regclass`
       )
     );
     console.log('Connected to database!');

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "dotenv": "^16.0.1",
         "express": "^4.18.1",
-        "pg": "^8.7.3"
+        "postgres": "^3.2.4"
       },
       "devDependencies": {
         "axios": "^0.27.2",
@@ -1601,14 +1601,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
-    },
-    "node_modules/buffer-writer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -4363,11 +4355,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/packet-reader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4443,80 +4430,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
-    },
-    "node_modules/pg": {
-      "version": "8.7.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
-      "integrity": "sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==",
-      "dependencies": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.5.0",
-        "pg-pool": "^3.5.1",
-        "pg-protocol": "^1.5.0",
-        "pg-types": "^2.1.0",
-        "pgpass": "1.x"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "peerDependencies": {
-        "pg-native": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "pg-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
-    },
-    "node_modules/pg-int8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/pg-pool": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.1.tgz",
-      "integrity": "sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ==",
-      "peerDependencies": {
-        "pg": ">=8.0"
-      }
-    },
-    "node_modules/pg-protocol": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
-      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
-    },
-    "node_modules/pg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "postgres-array": "~2.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.4",
-        "postgres-interval": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pgpass": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
-      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
-      "dependencies": {
-        "split2": "^4.1.0"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -4627,39 +4540,13 @@
         "node": ">=8"
       }
     },
-    "node_modules/postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postgres-date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postgres-interval": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+    "node_modules/postgres": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.2.4.tgz",
+      "integrity": "sha512-iscysD+ZlM4A9zj0RS2zo3f4Us4yuov94Yx+p3dE1rEARaBHC8R3/gRq40KEnWp1lxjuFq9EjuAenIUsPaTaDA==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
       }
     },
     "node_modules/prelude-ls": {
@@ -5063,14 +4950,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/split2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
-      "engines": {
-        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -5527,14 +5406,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {
@@ -6833,11 +6704,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
-    },
-    "buffer-writer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw=="
     },
     "bytes": {
       "version": "3.1.2",
@@ -8901,11 +8767,6 @@
       "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
       "dev": true
     },
-    "packet-reader": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
-    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8960,61 +8821,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
-    },
-    "pg": {
-      "version": "8.7.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.7.3.tgz",
-      "integrity": "sha512-HPmH4GH4H3AOprDJOazoIcpI49XFsHCe8xlrjHkWiapdbHK+HLtbm/GQzXYAZwmPju/kzKhjaSfMACG+8cgJcw==",
-      "requires": {
-        "buffer-writer": "2.0.0",
-        "packet-reader": "1.0.0",
-        "pg-connection-string": "^2.5.0",
-        "pg-pool": "^3.5.1",
-        "pg-protocol": "^1.5.0",
-        "pg-types": "^2.1.0",
-        "pgpass": "1.x"
-      }
-    },
-    "pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
-    },
-    "pg-int8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
-    },
-    "pg-pool": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.5.1.tgz",
-      "integrity": "sha512-6iCR0wVrro6OOHFsyavV+i6KYL4lVNyYAB9RD18w66xSzN+d8b66HiwuP30Gp1SH5O9T82fckkzsRjlrhD0ioQ==",
-      "requires": {}
-    },
-    "pg-protocol": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
-      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
-    },
-    "pg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "requires": {
-        "pg-int8": "1.0.1",
-        "postgres-array": "~2.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.4",
-        "postgres-interval": "^1.1.0"
-      }
-    },
-    "pgpass": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
-      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
-      "requires": {
-        "split2": "^4.1.0"
-      }
     },
     "picocolors": {
       "version": "1.0.0",
@@ -9094,28 +8900,10 @@
         }
       }
     },
-    "postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
-    },
-    "postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
-    },
-    "postgres-date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
-    },
-    "postgres-interval": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "requires": {
-        "xtend": "^4.0.0"
-      }
+    "postgres": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.2.4.tgz",
+      "integrity": "sha512-iscysD+ZlM4A9zj0RS2zo3f4Us4yuov94Yx+p3dE1rEARaBHC8R3/gRq40KEnWp1lxjuFq9EjuAenIUsPaTaDA=="
     },
     "prelude-ls": {
       "version": "1.2.1",
@@ -9408,11 +9196,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "split2": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
-      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -9754,11 +9537,6 @@
         "imurmurhash": "^0.1.4",
         "signal-exit": "^3.0.7"
       }
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
-    "pg": "^8.7.3"
+    "postgres": "^3.2.4"
   },
   "devDependencies": {
     "axios": "^0.27.2",

--- a/questions/questions.controller.js
+++ b/questions/questions.controller.js
@@ -72,7 +72,7 @@ module.exports.getQuestions = async (context) => {
   const rows = await dal.queryQuestionsByProductId(
     context.productId,
     context.count,
-    context.page,
+    context.page
   );
 
   return {
@@ -85,7 +85,7 @@ module.exports.getAnswers = async (context) => {
   const rows = await dal.queryAnswersByQuestionId(
     context.questionId,
     context.count,
-    context.page,
+    context.page
   );
 
   return {
@@ -96,21 +96,25 @@ module.exports.getAnswers = async (context) => {
   };
 };
 
-module.exports.addQuestion = async (context) => await dal.insertQuestion(
-  context.productId,
-  context.body,
-  context.name,
-  context.email,
-);
+module.exports.addQuestion = async (context) =>
+  await dal.insertQuestion(
+    context.productId,
+    context.body,
+    context.name,
+    context.email
+  );
 
-module.exports.addAnswer = async (context) => await dal.insertAnswer(
-  context.questionId,
-  context.body,
-  context.name,
-  context.email,
-  context.photos,
-);
+module.exports.addAnswer = async (context) =>
+  await dal.insertAnswer(
+    context.questionId,
+    context.body,
+    context.name,
+    context.email,
+    context.photos
+  );
 
-module.exports.markHelpful = async (context) => await dal.incrementHelpfulness(context.table, context.id);
+module.exports.markHelpful = async (context) =>
+  await dal.incrementHelpfulness(context.table, context.id);
 
-module.exports.markReported = async (context) => await dal.report(context.table, context.id);
+module.exports.markReported = async (context) =>
+  await dal.report(context.table, context.id);

--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 const express = require('express');
 const controller = require('./questions');
-const closeDbPool = require('./db').end;
+const sql = require('./db');
 
 const app = express();
 
@@ -101,7 +101,7 @@ const server = app.listen(process.env.PORT, () => {
 });
 
 const closeServer = async () => {
-  await closeDbPool();
+  await sql.end();
   await new Promise((resolve) => {
     server.close(() => {
       resolve();

--- a/server.js
+++ b/server.js
@@ -101,11 +101,9 @@ const server = app.listen(process.env.PORT, () => {
 });
 
 const closeServer = async () => {
-  await sql.end();
+  await sql.end({ timeout: 0.1 });
   await new Promise((resolve) => {
-    server.close(() => {
-      resolve();
-    });
+    server.close(resolve);
   });
 };
 

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -1,7 +1,6 @@
 require('dotenv').config();
 const dockerCompose = require('docker-compose');
 const path = require('path');
-const { Client } = require('pg');
 
 process.env.PGHOST = 'localhost';
 process.env.PGPORT = 54310;
@@ -10,15 +9,24 @@ process.env.PGUSER = 'postgres';
 process.env.PGPASSWORD = 'pw';
 process.env.PORT = 3010;
 
+const postgres = require('postgres');
+
+const sql = postgres();
+
 const checkDatabase = async () => {
   let connected = false;
   let timeoutReached = false;
 
-  const getClient = async () => {
+  const checkConnection = async () => {
     try {
-      const client = new Client();
-      await client.connect();
-      await client.end();
+      await Promise.all(
+        ['questions', 'answers', 'answers_photos'].map(async (table) => {
+          const result = await sql`SELECT * FROM ${sql(table)} LIMIT 1`;
+          if (result.length === 0) {
+            throw new Error();
+          }
+        })
+      );
       connected = true;
       console.log('Connected to database!');
     } catch (error) {
@@ -31,11 +39,11 @@ const checkDatabase = async () => {
       console.log('Unable to connect to database!');
     }
     timeoutReached = true;
-  }, 5000);
+  }, 10000);
 
   console.log('Connecting to database...');
   while (!connected && !timeoutReached) {
-    await getClient();
+    await checkConnection();
   }
 };
 


### PR DESCRIPTION
## postgres.js driver performance

| Test parameters |  avg response time (ms) | min/max response time (ms) | response counts | RPS | error rate |
| --- | --- | --- | --- | --- | --- |
| 1 request/s for 1 min | 67 | 62/163 | 60 | 1 |0%  |
| 100 requests/s for 1 min | 64 | 61/187 | 6000 | 100 | 0% |
| 1000 requests/s for 1 min | 1289 | 61/2583 | 57598 | 960 | 0% |
| 1000 requests/s for 1 min (2nd of batch) | 66 | 61/264 | 60000 | 1000 | 0% |
| 1000 requests/s for 1 min (3rd of batch) | 69 | 61/360 | 60000 |  1000 | 0% |
| 2000 requests/s for 1 min | 3252 | 76/4615 | 60277 | 1005 | 0% |
| 5000 requests/s for 1 min | 14522 | 124/50695 | 33322 |  555 | 0% |
| 10,000 requests/s for 1 min | 20193 | 129/59266 | 6085 | 101 | 0% |
| 10,000 requests/s for 1 min | 18045 | 125/59851 | 7344 | 122 | 0% |

## Analysis
The first test at 1000 RPS showed pretty poor performance (although still drastically better than the `node-postgres` driver). Subsequent tests at 1000 RPS showed great performance, possibly due to the impact of prepared statements from previous tests. With this change, performance at 1000 RPS is satisfactory and the next goal is a similar performance at 2000 RPS.

With this change, RPS seems to top out at about 1000, given the requests at 2000 requests/s.

Changing the max number of connections to the postgres server from 10 to 50 or 100 actually produced significantly worse performance, so I will keep it at 10 connections.

## Conclusion
Overall, performance improved significantly. I will be incorporating these changes into `main`.